### PR TITLE
feat: redesign landing page with Apple-inspired UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm install        # Install dependencies
+npm run format     # Format all files with Prettier
+npm run pre-commit # Check formatting (used in CI)
+```
+
+There is no build step — this is a static HTML site served directly.
+
+## Architecture
+
+Single-page static portfolio site (`index.html`) deployed to GitHub Pages. No framework, no build pipeline, no custom JavaScript.
+
+- **HTML**: `index.html` — the entire site
+- **CSS**: `style.css` — minimal responsive overrides on top of Bootstrap 4
+- **Assets**: `imgs/` (photos), `res/` (PDFs like CV and thesis)
+- **External CDNs**: Bootstrap 4.3.1, jQuery, Font Awesome 4.7.0, Google Fonts (Noto Sans Display)
+- **Analytics**: Google Analytics via GTM (UA-149415453-1)
+
+CI runs Prettier format check on PRs and pushes to `master`/`develop`.

--- a/index.html
+++ b/index.html
@@ -1,13 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Required meta tags -->
     <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1,
-      shrink-to-fit=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="title" content="Luciano Perezzini" />
     <meta
       name="description"
@@ -16,10 +11,6 @@
     />
     <meta name="robots" content="index,follow" />
     <meta name="googlebot" content="index,follow" />
-
-    <style>
-      @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+Display&display=swap");
-    </style>
 
     <!-- Open Graph data -->
     <meta property="og:title" content="Luciano Perezzini" />
@@ -34,6 +25,7 @@
     />
     <meta property="og:description" content="Luciano Perezzini" />
 
+    <!-- Font Awesome -->
     <link
       href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
       rel="stylesheet"
@@ -50,258 +42,209 @@
         dataLayer.push(arguments);
       }
       gtag("js", new Date());
-
       gtag("config", "UA-149415453-1");
     </script>
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
 
     <link href="style.css" rel="stylesheet" />
-
     <title>Luciano Perezzini</title>
   </head>
 
-  <body class="d-flex flex-column h-100">
-    <!-- Begin page content -->
-    <div class="container">
-      <div class="row align-items-center">
-        <div class="col-md-2 d-flex align-items-center justify-content-center">
-          <img
-            src="imgs/profile-1.jpeg"
-            alt="Profile image"
-            class="rounded-circle img-fluid shadow"
-            id="profile-image"
-          />
-        </div>
-        <div class="col-md-10" style="position: relative; top: -15px">
-          <h1 class="mt-5">Luciano Perezzini</h1>
-          <p class="font-weight-bold">Licentiate in Computer Science</p>
-        </div>
-      </div>
+  <body>
+    <main>
+      <!-- Hero -->
+      <header class="hero">
+        <img
+          src="imgs/profile-1.jpeg"
+          alt="Luciano Perezzini"
+          class="avatar"
+        />
+        <h1>Luciano Perezzini</h1>
+        <p class="subtitle">Licentiate in Computer Science</p>
+      </header>
 
-      <p>
-        Passionate and product-oriented technologist experienced in both
-        contributing to and building start-ups from scratch. Skilled at working
-        at the intersection of software, design, and AI to create innovative
-        technology products and services that captivate diverse audiences. With
-        expertise in information retrieval and a focus on accelerating digital
-        transformation, Luciano has a proven track record of delivering
-        data-driven solutions and collaborating with talented, hardworking
-        teams. As a human-computer interaction enthusiast and designer at heart,
-        he thrives on creating seamless user experiences.
-      </p>
-
-      <p>
-        Degree obtained from
-        <a href="http://unr.edu.ar" target="_blank"
-          >Universidad Nacional de Rosario</a
-        >
-        (2019). Thesis titled
-        <i
-          ><a href="https://bit.ly/3n6JIUJ" target="_blank"
-            >Towards Legal Engineering decision support systems</a
-          ></i
-        >, developed at
-        <a href="https://www.cifasis-conicet.gov.ar/" target="_blank"
-          >CIFASIS-CONICET</a
-        >
-        ― design of state-of-the-art LegalTech recommender systems applying
-        Information Retrieval and Natural Language Processing techniques.
-      </p>
-
-      <div
-        class="btn-group btn-group-sm"
-        role="group"
-        aria-label="Basic
-        example"
-      >
-        <a
-          href="res/thesis.pdf"
-          class="btn btn-outline-primary"
-          role="button"
-          target="_blank"
-          ><i class="fa fa-file-pdf-o"></i> Thesis</a
-        >
-        <a
-          href="res/thesis-defense.pdf"
-          class="btn btn-outline-primary"
-          role="button"
-          target="_blank"
-          ><i class="fa fa-file-pdf-o"></i> Thesis Defense</a
-        >
-      </div>
-
-      <br />
-      <br />
-
-      <div class="container">
-        <p class="text-secondary">
-          Luciano mostly works on Information Retrieval areas to accelerate
-          digital transformation adoption of businesses.
+      <!-- Bio -->
+      <section>
+        <p>
+          Luciano Perezzini is a technologist and product builder with deep
+          expertise in artificial intelligence, information retrieval, and
+          software engineering. He has spent his career at the intersection of
+          software, design, and AI &#8212; contributing to and building
+          startups from the ground up, with a consistent focus on accelerating
+          digital transformation through data-driven products and services.
+          Bridging technical depth with design sensibility, he brings a
+          background in natural language processing and a genuine interest in
+          human-computer interaction to every product he works on, thriving in
+          ambitious, collaborative environments where rigorous engineering and
+          thoughtful user experience go hand in hand.
         </p>
+      </section>
 
-        <p class="text-secondary">
-          Since 2021, he has been leading Data & Cloud Computing areas at
+      <!-- Education -->
+      <section>
+        <p>
+          Degree obtained from
+          <a href="http://unr.edu.ar" target="_blank"
+            >Universidad Nacional de Rosario</a
+          >
+          (2019). Thesis titled
+          <em
+            ><a href="https://bit.ly/3n6JIUJ" target="_blank"
+              >Towards Legal Engineering decision support systems</a
+            ></em
+          >, developed at
+          <a href="https://www.cifasis-conicet.gov.ar/" target="_blank"
+            >CIFASIS-CONICET</a
+          >
+          &#8212; design of state-of-the-art LegalTech recommender systems
+          applying Information Retrieval and Natural Language Processing
+          techniques.
+        </p>
+        <div class="btn-row">
+          <a href="res/thesis.pdf" class="btn btn-outline" target="_blank">
+            <i class="fa fa-file-pdf-o"></i> Thesis
+          </a>
+          <a
+            href="res/thesis-defense.pdf"
+            class="btn btn-outline"
+            target="_blank"
+          >
+            <i class="fa fa-file-pdf-o"></i> Thesis Defense
+          </a>
+        </div>
+      </section>
+
+      <!-- Current work -->
+      <section>
+        <p class="secondary">
+          His work centers on applying information retrieval and machine
+          learning to drive digital transformation across industries. Since
+          2021, he has served as Chief Data Officer at
           <a
             href="https://deepagro.com"
             target="_blank"
-            rel="noopener
-            noreferrer"
+            rel="noopener noreferrer"
             >DeepAgro</a
-          >, where he serves as Chief Data Officer, responsible for expanding
-          daily Business Intelligence and Machine Learning operations.
+          >, where he leads the Data and Cloud Computing division, overseeing
+          the design and scaling of business intelligence and machine learning
+          operations.
         </p>
+      </section>
 
-        <p class="text-secondary">
-          For an extensive review of Luciano's professional experience, visit
-          his
+      <!-- CTAs -->
+      <section>
+        <div class="btn-row">
+          <a
+            href="https://bit.ly/perezzini-resume"
+            class="btn btn-primary"
+            target="_blank"
+          >
+            <i class="fa fa-cloud-download"></i> Download Resume
+          </a>
+          <a
+            href="https://cal.com/perezzini"
+            class="btn btn-outline"
+            target="_blank"
+          >
+            <i class="fa fa-calendar-o"></i> Schedule a Call
+          </a>
+          <a
+            href="mailto:lperezzini@gmail.com"
+            class="btn btn-outline"
+            target="_blank"
+          >
+            <i class="fa fa-envelope-o"></i> Send an E-mail
+          </a>
+        </div>
+      </section>
+
+      <hr class="divider" />
+
+      <!-- Tags -->
+      <section>
+        <div class="tags">
+          <span class="tag">Artificial intelligence</span>
+          <span class="tag">Automation</span>
+          <span class="tag">Human-computer interaction</span>
+          <span class="tag">Information retrieval</span>
+          <span class="tag">Digital transformation</span>
+          <span class="tag">SaaS</span>
+          <span class="tag">Cloud computing</span>
+          <span class="tag">Natural language processing</span>
+        </div>
+      </section>
+
+      <!-- Social links -->
+      <section>
+        <div class="social-links">
           <a
             href="https://linkedin.com/in/perezzini"
             target="_blank"
-            rel="noopener noreferrer"
-            >LinkedIn profile</a
-          >.
-        </p>
-      </div>
-
-      <p>
-        <a
-          href="https://bit.ly/perezzini-resume"
-          class="btn btn-primary"
-          role="button"
-          target="_blank"
-          ><i class="fa fa-cloud-download"></i> Download Resume</a
-        >
-      </p>
-
-      <p>
-        <a
-          href="https://cal.com/perezzini"
-          class="btn btn-info btn-md"
-          role="button"
-          target="_blank"
-          ><i class="fa fa-calendar-o"></i> Schedule a Call</a
-        >
-
-        <a
-          href="mailto:lperezzini@gmail.com"
-          class="btn btn-info btn-md"
-          role="button"
-          target="_blank"
-          ><i class="fa fa-envelope-o"></i> Send an E-mail</a
-        >
-      </p>
-
-      <p>
-        <span class="badge badge-pill badge-secondary"
-          >Artificial intelligence</span
-        >
-        <span class="badge badge-pill badge-secondary">Automation</span>
-        <span class="badge badge-pill badge-secondary"
-          >Human-computer interaction</span
-        >
-        <span class="badge badge-pill badge-secondary"
-          >Information retrieval</span
-        >
-        <span class="badge badge-pill badge-secondary"
-          >Digital transformation</span
-        >
-        <span class="badge badge-pill badge-secondary">SaaS</span>
-        <span class="badge badge-pill badge-secondary">Cloud computing</span>
-        <span class="badge badge-pill badge-secondary"
-          >Natural language processing</span
-        >
-      </p>
-
-      <br />
-
-      <div class="btn-group" role="group">
-        <a
-          href="https://linkedin.com/in/perezzini"
-          target="_blank"
-          class="btn btn-outline-primary btn-md"
-          role="button"
-          ><i class="fa fa-linkedin-square"></i
-        ></a>
-        <a
-          href="https://github.com/perezzini"
-          target="_blank"
-          class="btn btn-outline-primary btn-md"
-          role="button"
-          ><i class="fa fa-github-square"></i
-        ></a>
-        <a
-          href="https://scholar.google.com/citations?user=Ad47r-MAAAAJ&hl=en"
-          target="_blank"
-          class="btn btn-outline-primary btn-md"
-          role="button"
-          ><i class="fa fa-graduation-cap"></i
-        ></a>
-        <a
-          href="https://twitter.com/perezzini"
-          target="_blank"
-          class="btn btn-outline-primary btn-md"
-          role="button"
-          ><i class="fa fa-twitter-square"></i
-        ></a>
-        <a
-          href="https://behance.net/lperezzini"
-          target="_blank"
-          class="btn btn-outline-primary btn-md"
-          role="button"
-          ><i class="fa fa-behance-square"></i
-        ></a>
-      </div>
-
-      <div class="container">
-        <div class="row">
-          <div class="mt-5">
-            <h4 class="text-info">Academic publications</h4>
-            <p class="font-weight-light">
-              • Perezzini, L., Casali, A., Deco, C.: Sistema de Soporte para la
-              Recuperación de Normativas en la Ingeniería Legal. In: XLIX
-              Simposio Argentino de Informática y Derecho (2020),
-              <a
-                href="https://49jaiio.sadio.org.ar/Anales/SID/Contribuciones"
-                target="_blank"
-                >SID 2020</a
-              >
-              <a
-                href="https://49jaiio.sadio.org.ar/pdfs/sid/SID-09.pdf"
-                target="_blank"
-                >[pdf]</a
-              >
-              <a href="https://youtu.be/q8MtVUa6-ZM?t=13143" target="_blank"
-                >[video]</a
-              >
-            </p>
-          </div>
-          <div class="col-sm"></div>
+            class="social-link"
+            aria-label="LinkedIn"
+          >
+            <i class="fa fa-linkedin-square"></i>
+          </a>
+          <a
+            href="https://github.com/perezzini"
+            target="_blank"
+            class="social-link"
+            aria-label="GitHub"
+          >
+            <i class="fa fa-github-square"></i>
+          </a>
+          <a
+            href="https://scholar.google.com/citations?user=Ad47r-MAAAAJ&hl=en"
+            target="_blank"
+            class="social-link"
+            aria-label="Google Scholar"
+          >
+            <i class="fa fa-graduation-cap"></i>
+          </a>
+          <a
+            href="https://twitter.com/perezzini"
+            target="_blank"
+            class="social-link"
+            aria-label="Twitter"
+          >
+            <i class="fa fa-twitter-square"></i>
+          </a>
+          <a
+            href="https://behance.net/lperezzini"
+            target="_blank"
+            class="social-link"
+            aria-label="Behance"
+          >
+            <i class="fa fa-behance-square"></i>
+          </a>
         </div>
-      </div>
-    </div>
+      </section>
 
-    <!-- Optional JavaScript -->
-    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-    <script
-      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
-      crossorigin="anonymous"
-    ></script>
+      <hr class="divider" />
+
+      <!-- Publications -->
+      <section>
+        <h2>Academic publications</h2>
+        <ul class="publications">
+          <li>
+            Perezzini, L., Casali, A., Deco, C.: Sistema de Soporte para la
+            Recuperación de Normativas en la Ingeniería Legal. In: XLIX
+            Simposio Argentino de Informática y Derecho (2020),
+            <a
+              href="https://49jaiio.sadio.org.ar/Anales/SID/Contribuciones"
+              target="_blank"
+              >SID 2020</a
+            >
+            <a
+              href="https://49jaiio.sadio.org.ar/pdfs/sid/SID-09.pdf"
+              target="_blank"
+              >[pdf]</a
+            >
+            <a href="https://youtu.be/q8MtVUa6-ZM?t=13143" target="_blank"
+              >[video]</a
+            >
+          </li>
+        </ul>
+      </section>
+    </main>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -53,11 +53,7 @@
     <main>
       <!-- Hero -->
       <header class="hero">
-        <img
-          src="imgs/profile-1.jpeg"
-          alt="Luciano Perezzini"
-          class="avatar"
-        />
+        <img src="imgs/profile-1.jpeg" alt="Luciano Perezzini" class="avatar" />
         <h1>Luciano Perezzini</h1>
         <p class="subtitle">Licentiate in Computer Science</p>
       </header>
@@ -68,14 +64,14 @@
           Luciano Perezzini is a technologist and product builder with deep
           expertise in artificial intelligence, information retrieval, and
           software engineering. He has spent his career at the intersection of
-          software, design, and AI &#8212; contributing to and building
-          startups from the ground up, with a consistent focus on accelerating
-          digital transformation through data-driven products and services.
-          Bridging technical depth with design sensibility, he brings a
-          background in natural language processing and a genuine interest in
-          human-computer interaction to every product he works on, thriving in
-          ambitious, collaborative environments where rigorous engineering and
-          thoughtful user experience go hand in hand.
+          software, design, and AI &#8212; contributing to and building startups
+          from the ground up, with a consistent focus on accelerating digital
+          transformation through data-driven products and services. Bridging
+          technical depth with design sensibility, he brings a background in
+          natural language processing and a genuine interest in human-computer
+          interaction to every product he works on, thriving in ambitious,
+          collaborative environments where rigorous engineering and thoughtful
+          user experience go hand in hand.
         </p>
       </section>
 
@@ -227,8 +223,8 @@
         <ul class="publications">
           <li>
             Perezzini, L., Casali, A., Deco, C.: Sistema de Soporte para la
-            Recuperación de Normativas en la Ingeniería Legal. In: XLIX
-            Simposio Argentino de Informática y Derecho (2020),
+            Recuperación de Normativas en la Ingeniería Legal. In: XLIX Simposio
+            Argentino de Informática y Derecho (2020),
             <a
               href="https://49jaiio.sadio.org.ar/Anales/SID/Contribuciones"
               target="_blank"

--- a/style.css
+++ b/style.css
@@ -1,17 +1,206 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 body {
-  font-family: "Noto Sans Display", sans-serif;
-  background-color: white;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text",
+    "Helvetica Neue", Arial, sans-serif;
+  background-color: #ffffff;
+  color: #1d1d1f;
+  line-height: 1.7;
 }
 
-.container {
-  width: auto;
-  max-width: 680px;
-  padding: 0 15px;
+main {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 72px 24px 96px;
 }
 
-/* Hide the profile image on mobile devices */
-@media (max-width: 767px) {
-  #profile-image {
-    display: none;
-  }
+/* Hero */
+
+.hero {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.avatar {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+  margin: 0 auto 20px;
+}
+
+h1 {
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  line-height: 1.1;
+  color: #1d1d1f;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  font-size: 19px;
+  color: #6e6e73;
+  font-weight: 400;
+}
+
+/* Sections */
+
+section {
+  margin-bottom: 32px;
+}
+
+/* Typography */
+
+p {
+  font-size: 17px;
+  line-height: 1.7;
+  color: #1d1d1f;
+  margin-bottom: 16px;
+}
+
+p:last-child {
+  margin-bottom: 0;
+}
+
+p.secondary {
+  color: #6e6e73;
+}
+
+a {
+  color: #0071e3;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+h2 {
+  font-size: 21px;
+  font-weight: 600;
+  color: #1d1d1f;
+  letter-spacing: -0.2px;
+  margin-bottom: 16px;
+}
+
+/* Divider */
+
+.divider {
+  border: none;
+  border-top: 1px solid #d2d2d7;
+  margin: 40px 0;
+}
+
+/* Buttons */
+
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 20px;
+  border-radius: 980px;
+  font-size: 15px;
+  font-weight: 500;
+  font-family: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  line-height: 1;
+}
+
+.btn:hover {
+  text-decoration: none;
+}
+
+.btn-primary {
+  background-color: #0071e3;
+  color: #ffffff;
+  border-color: #0071e3;
+}
+
+.btn-outline {
+  background-color: transparent;
+  color: #0071e3;
+  border-color: #0071e3;
+}
+
+/* Tags */
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  background-color: #f5f5f7;
+  color: #1d1d1f;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 5px 12px;
+  border-radius: 980px;
+}
+
+/* Social links */
+
+.social-links {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.social-link {
+  color: #6e6e73;
+  font-size: 24px;
+  text-decoration: none;
+  line-height: 1;
+}
+
+.social-link:hover {
+  color: #1d1d1f;
+  text-decoration: none;
+}
+
+/* Publications */
+
+.publications {
+  list-style: none;
+  padding: 0;
+}
+
+.publications li {
+  font-size: 15px;
+  line-height: 1.65;
+  color: #1d1d1f;
+  padding-left: 20px;
+  position: relative;
+}
+
+.publications li::before {
+  content: "·";
+  position: absolute;
+  left: 4px;
+  color: #6e6e73;
+  font-size: 20px;
+  line-height: 1.2;
 }

--- a/style.css
+++ b/style.css
@@ -204,3 +204,19 @@ h2 {
   font-size: 20px;
   line-height: 1.2;
 }
+
+/* Responsive */
+
+@media (max-width: 600px) {
+  main {
+    padding: 40px 20px 64px;
+  }
+
+  h1 {
+    font-size: 28px;
+  }
+
+  .subtitle {
+    font-size: 17px;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace Bootstrap/jQuery/Popper.js with a custom CSS design system (~200 lines)
- Apply Apple's exact design palette: `#1d1d1f` text, `#6e6e73` secondary, `#0071e3` accent blue
- Use system font stack (`-apple-system, BlinkMacSystemFont`) — renders as SF Pro on Apple devices
- Centered 640px layout with generous whitespace, pill-shaped buttons, and subtle dividers
- Rewrite bio and professional copy for a more concise, professional tone
- Add `CLAUDE.md` with project overview and development commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)