### PR TITLE
fix: dark mode toggle mobile overlap

### DIFF
--- a/src/components/DarkModeToggle.astro
+++ b/src/components/DarkModeToggle.astro
@@ -26,22 +26,16 @@
     display: inline;
   }
   .dark-toggle {
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    z-index: 1000;
-    width: 40px;
-    height: 40px;
+    padding: 6px 10px;
+    border-radius: var(--radius-pill);
     display: flex;
     align-items: center;
     justify-content: center;
     background: var(--surface-glass);
     color: var(--text-primary);
     border: 1px solid var(--border-glass);
-    border-radius: 50%;
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
-    box-shadow: var(--shadow-glass);
     cursor: pointer;
     font-size: 14px;
     transition:

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -14,5 +14,5 @@ const isPubs = p === '/publications'
   <a href="/publications" class={`nav-link${isPubs ? ' active' : ''}`}
     >Academic publications</a
   >
+  <DarkModeToggle />
 </nav>
-<DarkModeToggle />


### PR DESCRIPTION
## Summary

- Dark mode toggle was `position: fixed` at `top: 20px; right: 20px`, colliding visually with the nav pill on mobile viewports
- Moved `<DarkModeToggle />` inside `<nav class="site-nav">` as the last child
- Restyled toggle from a standalone 40×40 circle to a pill-shaped button matching the nav rhythm (`padding: 6px 10px; border-radius: var(--radius-pill)`)

## Test plan

- [ ] Mobile (~390px): moon/sun icon sits as last item in the nav pill, no collision
- [ ] Desktop: nav pill centered with toggle flush at the right end
- [ ] Click toggle: theme switches, persists across reload (no FOUC)
- [ ] Light mode appearance unchanged