### PR TITLE
chore(nav): remove essays link from top navbar

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,13 +2,11 @@
 const { pathname } = Astro.url
 const p = pathname.replace(/\/$/, '') || '/'
 const isHome = p === '/'
-const isEssays = p.startsWith('/essays')
 const isPubs = p === '/publications'
 ---
 
 <nav class="site-nav">
   <a href="/" class={`nav-link${isHome ? ' active' : ''}`}>Home</a>
-  <a href="/essays" class={`nav-link${isEssays ? ' active' : ''}`}>Essays</a>
   <a href="/publications" class={`nav-link${isPubs ? ' active' : ''}`}
     >Academic publications</a
   >


### PR DESCRIPTION
## Summary
Removes the "Essays" link from the top navbar since no essays are published yet, so it currently leads to an empty listing page.

## Changes
- Drop the `/essays` nav link and its unused `isEssays` active-route check from `Navbar.astro`
- Essays feature (routes, content collection, layout) is untouched — link can be restored once there's content to publish

## Test plan
- `npx prettier --check src/components/Navbar.astro` passes
- Verified `/essays`, `/essays/[slug]`, and `BlogPreview.astro` are unaffected by the diff

Closes #24