### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.1.1](https://github.com/perezzini/perezzini.github.io/compare/v1.1.0...v1.1.1) (2026-07-11)
+
 ## [1.1.0](https://github.com/perezzini/perezzini.github.io/compare/v1.0.0...v1.1.0) (2026-07-10)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perezzini.github.io",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perezzini.github.io",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perezzini.github.io",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Luciano Perezzini professional website",
   "scripts": {
     "dev": "astro dev",

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,13 +2,11 @@
 const { pathname } = Astro.url
 const p = pathname.replace(/\/$/, '') || '/'
 const isHome = p === '/'
-const isEssays = p.startsWith('/essays')
 const isPubs = p === '/publications'
 ---
 
 <nav class="site-nav">
   <a href="/" class={`nav-link${isHome ? ' active' : ''}`}>Home</a>
-  <a href="/essays" class={`nav-link${isEssays ? ' active' : ''}`}>Essays</a>
   <a href="/publications" class={`nav-link${isPubs ? ' active' : ''}`}
     >Academic publications</a
   >


### PR DESCRIPTION
## Summary
Release **v1.1.1** — patch release. Merging to `master` triggers the GitHub Pages deploy.

## Changes
- Version bump `1.1.0` → `1.1.1` (SemVer PATCH — one `chore` since v1.1.0, no `feat`/`fix`).
- Update `CHANGELOG.md` (tool-generated via `standard-version`).
- Carries from `develop`: removal of the "Essays" link from the top navbar (#25) — essays feature routes/content untouched.

## Test plan
- `npm run check:format` — clean.
- `npm run build` — succeeds, all 4 routes render including `/essays` and `/essays/[slug]`.

## Merge notes
- Per GitFlow, merge with a **merge commit** (`--no-ff`), not squash.
- After merge: tag `v1.1.1`, prepare a draft GitHub release, and back-merge `master` → `develop`.