### PR TITLE
chore: sync master into develop after v1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.1.1](https://github.com/perezzini/perezzini.github.io/compare/v1.1.0...v1.1.1) (2026-07-11)
+
 ## [1.1.0](https://github.com/perezzini/perezzini.github.io/compare/v1.0.0...v1.1.0) (2026-07-10)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perezzini.github.io",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perezzini.github.io",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "perezzini.github.io",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Luciano Perezzini professional website",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
Back-merges `master` into `develop` after the v1.1.1 release (#26), so `develop` picks up the version bump and changelog entry.

## Changes
- Fast-forward of `master`'s release commit (`package.json`/`package-lock.json` → 1.1.1, `CHANGELOG.md` entry) onto `develop`.

## Test plan
- No source changes beyond version/changelog metadata already verified on the release PR.

## Merge notes
- Per GitFlow, merge with a **merge commit** (`--no-ff`), not squash.